### PR TITLE
added message styling for read and unread messages

### DIFF
--- a/src/scripts/friends/DirectMessage.js
+++ b/src/scripts/friends/DirectMessage.js
@@ -1,6 +1,5 @@
-
-import { getUsers } from "../data/provider.js"
-
+import { getUsers, patchRead } from "../data/provider.js"
+const applicationElement = document.querySelector(".giffygram")
 
 export const DirectMessage = (message) => {
 
@@ -10,7 +9,7 @@ export const DirectMessage = (message) => {
     const foundUser = users.find(user => user.id === message.userId)
 
     let directMessageHTML = `
-    <div class="message" id="message--${message.id}">
+    <div class="message read--${message.read}" id="message--${message.id}">
         <div class="message__author">From ${foundUser.name}</div>
         <div class="message__text">${message.text}</div>
     </div>

--- a/src/scripts/nav/NavBar.js
+++ b/src/scripts/nav/NavBar.js
@@ -18,9 +18,6 @@ export const NavBar = () => {
         <div class="search__icon">
         <img id="search__icon" src="../../images/search_icon.png" alt="searchIcon">
         </div>
-        <div class="navigation__item navigation__logout myProfile">
-        <button class="profileLink fakeLink" id="profile--${user.id}">My Profile</button>
-        </div>
         <div class="navigation__item navigation__message">
             <img id="directMessageIcon" src="/images/fountain-pen.svg" alt="Direct message">
             <div class="notification__count" id="unreadIcon">

--- a/src/styles/message.css
+++ b/src/styles/message.css
@@ -45,6 +45,10 @@
     justify-content: center;
 }
 
+.message__author {
+    font-weight: bold;
+    margin-bottom: 1rem;
+}
 .message {
     border: 1px dotted lightblue;
     padding: 2rem;
@@ -52,9 +56,30 @@
     box-shadow: 0.25rem 0.25rem 0.5rem rgb(143, 143, 143);
     margin: 0 25%;
     flex-basis: 50%;
+    text-align: center;
 }
 
-.message__author {
-    font-weight: bold;
-    margin-bottom: 1rem;
+.message:hover {
+    border: 1px dotted lightblue;
+    padding: 2rem;
+    border-radius: 0.5rem;
+    box-shadow: 0.25rem 0.25rem 0.5rem rgb(143, 143, 143);
+    margin: 0 25%;
+    flex-basis: 50%;
+    text-align: center;
+    background-color: rgb(210, 224, 243);
+}
+
+@keyframes mymove {
+  50% {border-color: rgb(69, 137, 214);}
+}
+
+.read--false {
+    border: 3px solid rgb(169, 196, 228);
+    animation: mymove 1s infinite;
+}
+
+.read--false:hover {
+    border: 3px solid rgb(81, 153, 235);
+    animation: mymove 1s infinite;
 }

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -68,7 +68,3 @@
 .user__search {
     margin: 0 0 0 1rem;
 }
-
-.myProfile {
-    margin: 0.25rem 0 0 5rem;
-}


### PR DESCRIPTION
#### Changes Made
1. Modified file `message.css` to include styling for messages that are read, vs. messages that are unread
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout messagecss
    ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    > when user views message list, unread messages should display a glowing blue border, and read messages should display normal
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.