### PR TITLE
added fetch PATCH function so that read property of messages is chang…

### DIFF
--- a/src/scripts/data/provider.js
+++ b/src/scripts/data/provider.js
@@ -284,3 +284,15 @@ export const deleteFollow = (followId) => {
             }
         )
 }
+
+export const patchRead = (readObj) => {
+    const fetchOptions = {
+        method: "PATCH",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        body: JSON.stringify(readObj)
+    }
+    return fetch(`${apiURL}/messages/${readObj.id}`, fetchOptions)
+    .then(response => response.json())
+}

--- a/src/scripts/friends/DirectMessage.js
+++ b/src/scripts/friends/DirectMessage.js
@@ -1,5 +1,4 @@
 import { getUsers, patchRead } from "../data/provider.js"
-const applicationElement = document.querySelector(".giffygram")
 
 export const DirectMessage = (message) => {
 
@@ -14,5 +13,11 @@ export const DirectMessage = (message) => {
         <div class="message__text">${message.text}</div>
     </div>
     `
+    const sendToAPI = {
+        id: message.id,
+        read: true
+    }
+    patchRead(sendToAPI)
+
     return directMessageHTML
 }


### PR DESCRIPTION
#### Changes Made
1. Modified file `provider.js` to include readPatch function that changes a property of a message object in the API
2. Modified file `DirectMessage.js` so that when a direct message is viewed, a readPatch function is called that changes the message's read property to true in the API
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout readpatch
    ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    > When user clicks on the message list icon, the message list should display with the unread messages displaying a glowing blue border
    > when the user clicks on the message list icon again, or selects any other navigation option, the unread message count in the nav bar should reset to zero, and the messages will display as read the next time they are viewed
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.

