### PR TITLE
added option to view user profile in navigation bar

### DIFF
--- a/src/scripts/nav/NavBar.js
+++ b/src/scripts/nav/NavBar.js
@@ -19,10 +19,13 @@ export const NavBar = () => {
         <img id="search__icon" src="../../images/search_icon.png" alt="searchIcon">
         </div>
         <div class="navigation__item navigation__message">
-            <img id="directMessageIcon" src="/images/fountain-pen.svg" alt="Direct message">
-            <div class="notification__count" id="unreadIcon">
-                ${messages.filter(message => message.recipientId === user && message.read === false).length}
-            </div>
+        <img id="directMessageIcon" src="/images/fountain-pen.svg" alt="Direct message">
+        <div class="notification__count" id="unreadIcon">
+        ${messages.filter(message => message.recipientId === user && message.read === false).length}
+        </div>
+        </div>
+        <div class="navigation__item myProfile">
+        <button class="profileLink fakeLink" id="profile--${user}">My Profile</button>
         </div>
         <div class="navigation__item navigation__logout">
             <button id="logout" class="fakeLink">Logout</button>

--- a/src/styles/navigation.css
+++ b/src/styles/navigation.css
@@ -59,6 +59,7 @@
 
 .navigation__logout {
     margin-right: 2em;
+    margin-left: 1em;
 }
 
 #directMessageIcon {


### PR DESCRIPTION
#### Changes Made
1. Modified file `NavBar.js` to include a button that looks like a link that will display the profile of the user one is logged in as
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout mec-myprofile
    ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    > when the user logs in, they should notice a link in the navigation bar to the left of the Log Out link that says My Profile
    > clicking on My Profile should display the profile of the user that one is logged in as
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.